### PR TITLE
Perma generator test and doc update

### DIFF
--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -581,6 +581,7 @@ Note:
 
 - If you configure ``base-url``, it should include a "/" after the hostname like this: ``https://demo.dataverse.org/``.
 - When using multiple PermaLink providers, you should avoid ambiguous authority/separator/shoulder combinations that would result in the same overall prefix.
+- Configuring PermaLink providers differing only by their separator values is not supported.
 - In general, PermaLink authority/shoulder values should be alphanumeric. For other cases, admins may need to consider the potential impact of special characters in S3 storage identifiers, resolver URLs, exports, etc.
 
 .. _dataverse.pid.*.handlenet:

--- a/src/test/java/edu/harvard/iq/dataverse/pidproviders/PidUtilTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/pidproviders/PidUtilTest.java
@@ -48,6 +48,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -64,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @JvmSetting(key = JvmSettings.PID_PROVIDER_LABEL, value = "perma 2", varArgs = "perma2")
 @JvmSetting(key = JvmSettings.PID_PROVIDER_TYPE, value = PermaLinkPidProvider.TYPE, varArgs = "perma2")
 @JvmSetting(key = JvmSettings.PID_PROVIDER_AUTHORITY, value = "DANSLINK", varArgs = "perma2")
-@JvmSetting(key = JvmSettings.PID_PROVIDER_SHOULDER, value = "QE", varArgs = "perma2")
+@JvmSetting(key = JvmSettings.PID_PROVIDER_SHOULDER, value = "QQ", varArgs = "perma2")
 @JvmSetting(key = JvmSettings.PID_PROVIDER_MANAGED_LIST, value = "perma:LINKIT/FK2ABCDEF", varArgs ="perma2")
 @JvmSetting(key = JvmSettings.PERMALINK_SEPARATOR, value = "/", varArgs = "perma2")
 @JvmSetting(key = JvmSettings.PERMALINK_BASE_URL, value = "https://example.org/123/citation?persistentId=perma:", varArgs = "perma2")
@@ -133,6 +134,8 @@ public class PidUtilTest {
 
     @Mock
     private SettingsServiceBean settingsServiceBean;
+    
+    static PidProviderFactoryBean pidService;
 
     @BeforeAll
     //FWIW @JvmSetting doesn't appear to work with @BeforeAll
@@ -228,12 +231,26 @@ public class PidUtilTest {
         assertEquals("perma1", pid3.getProviderId());
 
         //Repeat the basics with a permalink associated with perma2
-        String  pid4String = "perma:DANSLINK/QE-5A-XN55";
+        String  pid4String = "perma:DANSLINK/QQ-5A-XN55";
         GlobalId pid5 = PidUtil.parseAsGlobalID(pid4String);
         assertEquals("perma2", pid5.getProviderId());
         assertEquals(pid4String, pid5.asString());
         assertEquals("https://example.org/123/citation?persistentId=" + pid4String, pid5.asURL());
 
+    }
+    
+    @Test
+    public void testPermaLinkGenerationiWithSeparator() throws IOException {
+        Dataset ds = new Dataset();
+        pidService = Mockito.mock(PidProviderFactoryBean.class);
+        Mockito.when(pidService.isGlobalIdLocallyUnique(any(GlobalId.class))).thenReturn(true);
+        PidProvider p = PidUtil.getPidProvider("perma1");
+        p.setPidProviderServiceBean(pidService);
+        p.generatePid(ds);
+        System.out.println("DS sep " + ds.getSeparator());
+        System.out.println("Generated perma identifier" + ds.getGlobalId().asString());
+        System.out.println("Provider prefix for perma identifier" + p.getAuthority() + p.getSeparator() + p.getShoulder());
+        assertTrue(ds.getGlobalId().asRawIdentifier().startsWith(p.getAuthority() + p.getSeparator() + p.getShoulder()));
     }
     
     @Test


### PR DESCRIPTION
@vera - as I mentioned, here's a PR with a new test that should prove your PR fixes #11165. I also made a minor tweak to note that using two perma providers that just differ by separator fails (as I could see in the new test as perma1 and perma2 in the PidUtilTest had that issue.